### PR TITLE
gradle: Add groovy as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'distribution'
+    id 'groovy'
     id "org.openjfx.javafxplugin" version "0.0.9"
 }
 
@@ -22,9 +23,10 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compileOnly 'org.omegat:vldocking:3.0.5'
-    compileOnly 'org.omegat:omegat:5.2.0'
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    implementation 'org.omegat:vldocking:3.0.5'
+    implementation 'org.omegat:omegat:5.2.0'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.1'
+    testImplementation group: 'junit', name: 'junit', version: '4.11'
 }
 
 javafx {


### PR DESCRIPTION
scripts are written by groovy. IDE such as IntelliJ IDEA recognize scripts better by Adding groovy as a dependency and plugin. 